### PR TITLE
Enhance container parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Register
 The service will write the container dump file to Composer's parent directory (`vendor/../pimple.json`) by default. Set the ~~`dump.path`~~ `pimpledump.output_dir` parameter if you need to specify the output directory path.
 - Example: `$app['pimpledump.output_dir'] = '/tmp'`
 
-A container dump can be manually invoked by making a `GET` request to `http://your_project/_dump` or, if specified, the `pimpledump.trigger_route_pattern` parameter.
+A container dump can be manually invoked by making a `GET` request to `http://your_project/_dump` or, if provided, the route path pattern specified by the `pimpledump.trigger_route_pattern` parameter.
 - Example: `$app['pimpledump.trigger_route_pattern'] = '/_dump_pimple'`
 
 If you are in a dev enviroment (`$app['debug'] = true`) the service will *__automatically dump the container during shutdown__ if it wasn't done earlier within the lifecycle*.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Register
 	$app->register(new Sorien\Provider\PimpleDumpProvider());
 ```
 
-plugin will output container dump (`pimple.json`) to parent directory of vendor's dir, if you need to use different path set parameter `['dump.path']`
+The service will write the container dump file to Composer's parent directory (`vendor/../pimple.json`) by default. Set the ~~`dump.path`~~ `pimpledump.output_dir` parameter if you need to specify the output directory path.
+- Example: `$app['pimpledump.output_dir'] = '/tmp'`
 
-if you are in dev enviroment `['debug'] = true`, program will generate dump **automatically on finish event** or just visit `http://your_project/_dump` 
+A container dump can be manually invoked by making a `GET` request to `http://your_project/_dump` or, if specified, the `pimpledump.trigger_route_pattern` parameter.
+- Example: `$app['pimpledump.trigger_route_pattern'] = '/_dump_pimple'`
+
+If you are in a dev enviroment (`$app['debug'] = true`) the service will *__automatically dump the container during shutdown__ if it wasn't done earlier within the lifecycle*.

--- a/src/PimpleDumpProvider.php
+++ b/src/PimpleDumpProvider.php
@@ -157,8 +157,11 @@ class PimpleDumpProvider implements ControllerProviderInterface, ServiceProvider
         // Set defaults
         $param = self::DIC_PREFIX . '.output_dir';
         if (!isset($app[$param])) {
-            // parent of vendor directory
-            $app[$param] = dirname(dirname(dirname(dirname(__DIR__))));
+            // Provide backward compatibility via the old parameter
+            //  or set to the default — Composer's parent directory
+            $app[$param] = isset($app['dump.path'])
+              ? $app['dump.path']
+              : dirname(dirname(dirname(dirname(__DIR__))));
         }
 
         $param = self::DIC_PREFIX . '.trigger_route_pattern';


### PR DESCRIPTION
- Allow specifying the manual dump trigger route pattern (`$app['pimpledump.trigger_route_pattern'] = '/dump_pimple_json'`)
- Create prefix constant (`PimpleDumpProvider::DIC_PREFIX = 'pimpledump'`)
- Refactor output path parameter name (`pimpledump.output_dir`)
- A little bit of micro-refactoring (tangential, don't use `is_null()` or `is_integer()`, break down long lines)
- Update documentation
